### PR TITLE
Fix dkms building for currently not running kernel

### DIFF
--- a/src/kernel/dkms.conf
+++ b/src/kernel/dkms.conf
@@ -1,8 +1,8 @@
 BUILT_MODULE_NAME=hid-lg-g710-plus
 PACKAGE_NAME=hid-lg-g710-plus
 PACKAGE_VERSION=0.1
-MAKE="make"
-CLEAN="make clean"
+MAKE="make KVERSION=$kernelver"
+CLEAN="make clean KVERSION=$kernelver"
 DEST_MODULE_LOCATION="/updates"
 REMAKE_INITRD=yes 
 AUTOINSTALL="yes"


### PR DESCRIPTION
If you are using dkms to build the module for a installed kernel, that is not
runnig during compilation, you need to pass the kernel version from dkms to
the makefile.